### PR TITLE
Add  .nojekyll file to docs folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ script:
   # Sphinx build
   - make clean
   - make html
+  - touch _build/html/.nojekyll
   - diff -qr _build/html docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ script:
   # Install project dependencies
   - pip install -r requirements.txt
   # Make sure contributing.md is the latest version
-  - git clone https://${GH_TOKEN}@github.com/SubstraFoundation/.github.git
-  - cmp --silent .github/CONTRIBUTING.md src/contribute/CONTRIBUTING.md
+  - git clone https://${GH_TOKEN}@github.com/SubstraFoundation/.github.git dotgithub
+  - cmp --silent dotgithub/CONTRIBUTING.md src/contribute/CONTRIBUTING.md
   # Sphinx build
   - make clean
   - make html

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ help:
 docs: clean html
 	rm -rf docs/*
 	cp -R _build/html/ docs/
+	touch docs/.nojekyll
 
 livehtml:
 	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)/html -c "$(CONFDIR)"


### PR DESCRIPTION
- Makes sure the `docs/` folder contains a `/nojekyll` file
- Fixes a conflict in travis where cloning `.github.git` conflicted with the `.github/CODEOWNERS` directory.