### PR TITLE
chore(ci): update .readthedocs.yaml format

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/source/conf.py
@@ -15,6 +21,5 @@ formats: []
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.8
   install:
     - requirements: requirements.txt


### PR DESCRIPTION
ReadTheDocs is deprecating our current format (and a brownout is currently in progress, yipee): https://blog.readthedocs.com/use-build-os-config/

This updates the format of our `.readthedocs.yaml` to address this deprecation.